### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "v2.99.3-with-ruby3-compat"
+  pull_request:
+    branches:
+      - "v2.99.3-with-ruby3-compat"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.7']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: |
+          bundle exec rake test


### PR DESCRIPTION
This is the first PR for the "project" [mime-types v 2.99.3 with ruby 3 compatibility](https://github.com/onrunning/ruby-mime-types/wiki/v2.99.3-with-ruby-3-compatibility).

It does add CI for changes targeting the branch [v2.99.3-with-ruby3-compat](https://github.com/onrunning/ruby-mime-types/tree/v2.99.3-with-ruby3-compat).

#### Review instructions

- Check the workflow code
- Make sure that the status is green