### PR TITLE
v2.99.3 with ruby 3.0.X compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7']
+        ruby-version: ['2.7', '3.0']
 
     steps:
       - uses: actions/checkout@v4

--- a/lib/mime/types/logger.rb
+++ b/lib/mime/types/logger.rb
@@ -23,7 +23,7 @@ module MIME
         end
       end
 
-      def initialize(_1, _2 = nil, _3 = nil)
+      def initialize(_one, _two = nil, _three = nil)
         super nil
         @logdev = WarnLogDevice.new
         @formatter = ->(_s, _d, _p, m) { m }


### PR DESCRIPTION
This is the second PR for the "project" [mime-types v 2.99.3 with ruby 3 compatibility](https://github.com/onrunning/ruby-mime-types/wiki/v2.99.3-with-ruby-3-compatibility).

It does make the actual changes needed for ruby 3 compatibility

#### Review instructions

- Sanity check
- Verify green status